### PR TITLE
Correctly init _cachedKeyboardRect

### DIFF
--- a/Source/SLKTextViewController.m
+++ b/Source/SLKTextViewController.m
@@ -160,7 +160,7 @@ CGFloat const SLKAutoCompletionViewDefaultHeight = 140.0;
     self.automaticallyAdjustsScrollViewInsets = YES;
     self.extendedLayoutIncludesOpaqueBars = YES;
 
-    CGRect _cachedKeyboardRect;
+    _cachedKeyboardRect = CGRectNull;
 }
 
 


### PR DESCRIPTION
This moved the whole `tableView` to the top of the screen, because it was set to `(0,0),(0,0)` instead of `((Inf,Inf),(0,0))`.

See https://github.com/slackhq/SlackTextViewController/pull/652/files
